### PR TITLE
Change project configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 #Kotlin
 kotlin.code.style=official
-kotlin.js.compiler=ir
 #MPP
 kotlin.mpp.enableCInteropCommonization=true
 #Android

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.parallel=true
 #Kotlin
 kotlin.code.style=official
 #MPP

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.vanniktech.maven.publish.SonatypeHost
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -14,7 +13,6 @@ version = "0.0.1"
 kotlin {
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
     iosX64()
@@ -42,8 +42,8 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the build configuration and update the Java and Kotlin versions used in the project. The most important changes include enabling parallel execution in Gradle, updating the JVM target version, and removing an experimental Kotlin plugin API annotation.

Build configuration improvements:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R5-L7): Enabled parallel execution in Gradle by adding `org.gradle.parallel=true`.

Java and Kotlin version updates:

* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL17-R17): Updated the JVM target version from 11 to 17 in the `compilerOptions` block.
* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL47-R46): Updated the `sourceCompatibility` and `targetCompatibility` settings from Java 11 to Java 17.

Code cleanup:

* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL17-R17): Removed the `@OptIn(ExperimentalKotlinGradlePluginApi::class)` annotation.
* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL2): Removed the import statement for `ExperimentalKotlinGradlePluginApi`.