### PR TITLE
Revert "Update Java compatibility to JDK 17"

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.JVM_11)
         }
     }
     iosX64()
@@ -42,8 +42,8 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 }
 


### PR DESCRIPTION
This reverts commit 05742f36566c13675b216c4fe427c6ffa3d15191.

Because it requires users to have an application environment with Java 17 or higher.

Also, the current version of the template is Java 11:

https://github.com/Kotlin/multiplatform-library-template/blob/dc59e1c62a5f1f01b36717350d514a8b73ff9c06/library/build.gradle.kts#L20